### PR TITLE
ci(commitlint): add commit message lint workflow for PRs

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,26 @@
+name: Conventional Commits Lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, edited, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commitlint:
+    name: Lint commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run commitlint
+        uses: wagoid/commitlint-github-action@v6
+        with:
+          helpURL: https://www.conventionalcommits.org/zh-hant/v1.0.0/


### PR DESCRIPTION
### Purpose 
Add a GitHub Actions workflow to lint commit messages in pull requests

### Changes 
- Added `.github/workflows/commitlint.yml`
- Runs [wagoid/commitlint-github-action](https://github.com/wagoid/commitlint-github-action) on PR events

### Verification 
1. Open a test PR with a non-conforming commit message, e.g. `update`.
2. Check the **Checks** tab — the workflow should fail and display a lint error.
3. Push a commit with a valid message, e.g. `docs: update readme`, and verify the check passes.
