### PR TITLE
Feat/local storage

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -7,16 +7,16 @@ plugins {
 
 android {
     namespace = "com.example.amitabha"
-    compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    compileSdk = 35
+    ndkVersion = "27.0.12077973" 
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {
@@ -24,8 +24,8 @@ android {
         applicationId = "com.example.amitabha"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
-        targetSdk = flutter.targetSdkVersion
+        minSdk = 23
+        targetSdk = 35
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }

--- a/lib/storage/app_paths.dart
+++ b/lib/storage/app_paths.dart
@@ -4,8 +4,8 @@ import 'package:path/path.dart' as p;
 
 class AppPaths {
   static Future<Directory> _root() async {
-    final doc = await getApplicationDocumentsDirectory();
-    final dir = Directory(p.join(doc.path, 'namo'));
+    final doc = await getApplicationSupportDirectory();
+    final dir = Directory(p.join(doc.path, 'amitabha'));
     if (!await dir.exists()) await dir.create(recursive: true);
     return dir;
   }

--- a/lib/storage/app_paths.dart
+++ b/lib/storage/app_paths.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as p;
+
+class AppPaths {
+  static Future<Directory> _root() async {
+    final doc = await getApplicationDocumentsDirectory();
+    final dir = Directory(p.join(doc.path, 'namo'));
+    if (!await dir.exists()) await dir.create(recursive: true);
+    return dir;
+  }
+
+  static Future<File> sessionSnapshot(String sessionId) async {
+    final r = await _root();
+    final file = File(p.join(r.path, 'data', 'sessions', '$sessionId.json'));
+    await file.parent.create(recursive: true);
+    return file;
+  }
+
+  static Future<File> sessionHits(String sessionId, {int part = 1}) async {
+    final r = await _root();
+    final file = File(p.join(r.path, 'data', 'sessions', '$sessionId-hits-$part.ndjson'));
+    await file.parent.create(recursive: true);
+    return file;
+  }
+
+  static Future<File> daily(String yyyymmdd) async {
+    final r = await _root();
+    final file = File(p.join(r.path, 'data', 'daily', '$yyyymmdd.json'));
+    await file.parent.create(recursive: true);
+    return file;
+  }
+}

--- a/lib/storage/atomic_io.dart
+++ b/lib/storage/atomic_io.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+import 'dart:io';
+
+Future<void> atomicWriteJson(File file, Object jsonObj) async {
+  final dir = file.parent;
+  if (!await dir.exists()) {
+    await dir.create(recursive: true);
+  }
+
+  final tmp = File('${file.path}.tmp');
+  try {
+    final jsonStr = const JsonEncoder.withIndent('  ').convert(jsonObj);
+    await tmp.writeAsString(jsonStr, flush: true);
+
+    await tmp.rename(file.path);
+  } catch (e) {
+ 
+    if (await tmp.exists()) {
+      try { await tmp.delete(); } catch (_) {}
+    }
+    rethrow;
+  }
+}
+
+Future<Map<String, dynamic>> readJsonOrEmpty(File file) async {
+  if (!await file.exists()) return {};
+
+  String text;
+  try {
+    text = await file.readAsString();
+  } on IOException {
+    return {};
+  }
+
+  if (text.isEmpty) return {};
+
+  try {
+    final obj = jsonDecode(text);
+    if (obj is Map<String, dynamic>) return obj;
+    return {};
+  } on FormatException { 
+    return {};
+  }
+}

--- a/lib/storage/buffered_hits.dart
+++ b/lib/storage/buffered_hits.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+
+class BufferedHits {
+  final Duration flushEvery;
+  final int maxBuffer;
+  final Future<void> Function(List<DateTime>) onFlush;
+  final _buf = <DateTime>[];
+  Timer? _t;
+
+  BufferedHits({
+    required this.flushEvery,
+    required this.maxBuffer,
+    required this.onFlush,
+  });
+
+  void add(DateTime t) {
+    _buf.add(t);
+    if (_buf.length >= maxBuffer) { _flush(); }
+    else { _t ??= Timer(flushEvery, _flush); }
+  }
+
+  Future<void> _flush() async {
+    _t?.cancel(); _t = null;
+    if (_buf.isEmpty) return;
+    final copy = List<DateTime>.from(_buf);
+    _buf.clear();
+    await onFlush(copy);
+  }
+
+  Future<void> close() => _flush();
+}

--- a/lib/storage/daily_repo.dart
+++ b/lib/storage/daily_repo.dart
@@ -1,0 +1,31 @@
+import 'atomic_io.dart';
+import 'app_paths.dart';
+import 'models.dart';
+import 'single_writer.dart';
+
+class DailyRepository {
+  Future<void> addCount(String yyyymmdd, String userId, String userName, int delta) async {
+    final file = await AppPaths.daily(yyyymmdd);
+    await singleWriter.run(() async {
+      final j = await readJsonOrEmpty(file);
+      if (j.isEmpty) {
+        final d = DailySummary(
+          yyyymmdd: yyyymmdd,
+          userId: userId,
+          userName: userName,
+          amitabhaCount: delta,
+        );
+        await atomicWriteJson(file, d.toJson());
+      } else {
+        final d = DailySummary.fromJson(j);
+        final updated = DailySummary(
+          yyyymmdd: d.yyyymmdd,
+          userId: d.userId,
+          userName: d.userName,
+          amitabhaCount: d.amitabhaCount + delta,
+        );
+        await atomicWriteJson(file, updated.toJson());
+      }
+    });
+  }
+}

--- a/lib/storage/hit_logger.dart
+++ b/lib/storage/hit_logger.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+import 'dart:io';
+import 'app_paths.dart';
+import 'package:amitabha/utils.dart';
+
+class HitLogger {
+  final String sessionId;
+  int _part = 1;
+  int _lines = 0;
+  final int rotateEvery; 
+
+  HitLogger(this.sessionId, {this.rotateEvery = 5000});
+
+  Future<void> appendMany(Iterable<DateTime> hitsUtc) async {
+    var file = await AppPaths.sessionHits(sessionId, part: _part);
+    var sink = file.openWrite(mode: FileMode.append);
+    final encoder = JsonEncoder();
+
+    try {
+      for (final t in hitsUtc) {
+        sink.writeln(encoder.convert({'t': t.toIso8601String()}));
+        _lines++;
+        if (_lines >= rotateEvery) {
+          await sink.flush();
+          await sink.close();
+          _part++; _lines = 0;
+          file = await AppPaths.sessionHits(sessionId, part: _part);
+          sink = file.openWrite(mode: FileMode.append);
+        }
+      }
+    } finally {
+      await sink.flush();
+      await sink.close();
+    }
+  }
+
+  Future<void> initFromDisk() async {
+    var part = 1;
+    while (await AppPaths.sessionHits(sessionId, part: part + 1)
+        .then((f) => f.exists())) {
+      part++;
+    }
+    _part = part;
+
+    final file = await AppPaths.sessionHits(sessionId, part: _part);
+    if (await file.exists()) {
+      final lines = await file.openRead()
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .length;
+      _lines = lines;
+    } else {
+      _lines = 0;
+    }
+  }
+  static String todayYmdLocal() => nowYmdLocal();
+}

--- a/lib/storage/models.dart
+++ b/lib/storage/models.dart
@@ -1,0 +1,65 @@
+class SessionSnapshot {
+  final String sessionId;
+  final String userId;
+  final String userName;
+  final DateTime startedAt;
+  final DateTime lastAt;
+  final int amitabhaCount;
+
+  SessionSnapshot({
+    required this.sessionId,
+    required this.userId,
+    required this.userName,
+    required this.startedAt,
+    required this.lastAt,
+    required this.amitabhaCount,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'schemaVersion': 1,
+    'sessionId': sessionId,
+    'userId': userId,
+    'userName': userName,
+    'startedAt': startedAt.toUtc().toIso8601String(),
+    'lastAt': lastAt.toUtc().toIso8601String(),
+    'amitabhaCount': amitabhaCount,
+  };
+
+  static SessionSnapshot fromJson(Map<String, dynamic> j) => SessionSnapshot(
+    sessionId: j['sessionId'],
+    userId: j['userId'],
+    userName: j['userName'],
+    startedAt: DateTime.parse(j['startedAt']).toUtc(),
+    lastAt: DateTime.parse(j['lastAt']).toUtc(),
+    amitabhaCount: j['amitabhaCount'] ?? 0,
+  );
+}
+
+class DailySummary {
+  final String yyyymmdd;
+  final String userId;
+  final String userName;
+  final int amitabhaCount;
+
+  DailySummary({
+    required this.yyyymmdd,
+    required this.userId,
+    required this.userName,
+    required this.amitabhaCount,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'schemaVersion': 1,
+    'date': yyyymmdd,
+    'userId': userId,
+    'userName': userName,
+    'amitabhaCount': amitabhaCount,
+  };
+
+  static DailySummary fromJson(Map<String, dynamic> j) => DailySummary(
+    yyyymmdd: j['date'],
+    userId: j['userId'],
+    userName: j['userName'],
+    amitabhaCount: j['amitabhaCount'] ?? 0,
+  );
+}

--- a/lib/storage/session_repo.dart
+++ b/lib/storage/session_repo.dart
@@ -1,0 +1,19 @@
+import 'atomic_io.dart';
+import 'app_paths.dart';
+import 'models.dart';
+import 'single_writer.dart';
+
+class SessionRepository {
+  Future<void> upsertSnapshot(SessionSnapshot s) async {
+    final file = await AppPaths.sessionSnapshot(s.sessionId);
+    await singleWriter.run(() => atomicWriteJson(file, s.toJson()));
+  }
+
+  Future<SessionSnapshot?> readSnapshot(String sessionId) async {
+    final file = await AppPaths.sessionSnapshot(sessionId);
+    if (!await file.exists()) return null;
+    final j = await readJsonOrEmpty(file);
+    if (j.isEmpty) return null;
+    return SessionSnapshot.fromJson(j);
+  }
+}

--- a/lib/storage/single_writer.dart
+++ b/lib/storage/single_writer.dart
@@ -1,0 +1,11 @@
+class SingleWriter {
+  Future<void> _last = Future.value();
+
+  Future<T> run<T>(Future<T> Function() job) {
+    final next = _last.then((_) => job());
+    _last = next.then((_) {}, onError: (_) {});
+    return next;
+  }
+}
+
+final singleWriter = SingleWriter();

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -13,6 +13,7 @@ import 'package:http/http.dart' as http;
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
+import 'package:intl/intl.dart';
 import 'widgets/download_progress_dialog.dart';
 
 Float32List convertBytesToFloat32(Uint8List bytes, [Endian endian = Endian.little]) {
@@ -309,4 +310,8 @@ Future<void> _unzipDownloadedFile(
     Navigator.of(context).pop();
     _showSuccessDialog(context);
   }
+}
+
+String nowYmdLocal() {
+  return DateFormat('yyyyMMdd').format(DateTime.now()); // 本地時區
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -160,6 +160,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.4"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,8 @@ dependencies:
   url_launcher: ^6.2.6
   cupertino_icons: ^1.0.8
 
+  intl: ^0.20.2
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   

--- a/test/storage_test.dart
+++ b/test/storage_test.dart
@@ -1,0 +1,110 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import 'package:amitabha/storage/app_paths.dart';
+import 'package:amitabha/storage/atomic_io.dart';
+import 'package:amitabha/storage/daily_repo.dart';
+import 'package:amitabha/storage/hit_logger.dart';
+import 'package:amitabha/storage/models.dart';
+import 'package:amitabha/storage/session_repo.dart';
+
+String _nowYmdLocal() {
+  final n = DateTime.now();
+  return '${n.year.toString().padLeft(4, '0')}'
+         '${n.month.toString().padLeft(2, '0')}'
+         '${n.day.toString().padLeft(2, '0')}';
+}
+
+/// Mock path_provider
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.docs);
+  final Directory docs;
+  @override
+  Future<String?> getApplicationDocumentsPath() async => docs.path;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempRoot;
+
+  setUp(() async {
+    tempRoot = await Directory.systemTemp.createTemp('namo_test_');
+    PathProviderPlatform.instance = _FakePathProvider(tempRoot);
+  });
+
+  tearDown(() async {
+    if (await tempRoot.exists()) {
+      await tempRoot.delete(recursive: true);
+    }
+  });
+
+  test('DailyRepository.addCount 累加成功', () async {
+    final repo = DailyRepository();
+    final ymd = _nowYmdLocal();
+
+    await repo.addCount(ymd, 'u1', '使用者', 3);
+    await repo.addCount(ymd, 'u1', '使用者', 2);
+
+    final file = await AppPaths.daily(ymd);
+    final j = await readJsonOrEmpty(file);
+
+    expect(j['date'], ymd);
+    expect(j['amitabhaCount'], 5);
+  });
+
+  test('SessionRepository upsert / read 往返', () async {
+    final repo = SessionRepository();
+    final s = SessionSnapshot(
+      sessionId: 's1',
+      userId: 'u1',
+      userName: '使用者',
+      startedAt: DateTime.now().toUtc(),
+      lastAt: DateTime.now().toUtc(),
+      amitabhaCount: 42,
+    );
+
+    await repo.upsertSnapshot(s);
+    final got = await repo.readSnapshot('s1');
+
+    expect(got, isNotNull);
+    expect(got!.sessionId, 's1');
+    expect(got.amitabhaCount, 42);
+  });
+
+  test('HitLogger.appendMany 會寫出 NDJSON 且可輪檔', () async {
+    final logger = HitLogger('sessA', rotateEvery: 2);
+
+    await logger.appendMany([
+      DateTime.now().toUtc(),
+      DateTime.now().toUtc(),
+      DateTime.now().toUtc(),
+    ]);
+
+    final f1 = await AppPaths.sessionHits('sessA', part: 1);
+    final f2 = await AppPaths.sessionHits('sessA', part: 2);
+
+    expect(await f1.exists(), isTrue);
+    expect(await f2.exists(), isTrue);
+
+    final l1 = await f1.readAsLines();
+    final l2 = await f2.readAsLines();
+
+    expect(l1.length, 2);
+    expect(l2.length, 1);
+
+    final obj = jsonDecode(l1.first);
+    expect(obj, contains('t'));
+  });
+
+  test('atomicWriteJson 原子寫入成功', () async {
+    final file = File(p.join(tempRoot.path, 'namo', 'data', 'x.json'));
+    await atomicWriteJson(file, {'a': 1});
+    final j = await readJsonOrEmpty(file);
+    expect(j['a'], 1);
+  });
+}


### PR DESCRIPTION
###Summary
Ship a robust local file–based storage pipeline (buffer → single-writer → atomic write) with Session/Daily repos and NDJSON logs, move data to Application Support/internal files, add atomic model unzip with zip-slip guard, and fix UTC day bucketing, readJsonOrEmpty, snapshot lastAt, and HitLogger rotation.

### Added
- Local file storage pipeline (buffer → single-writer → atomic write)
- Session & Daily repositories; NDJSON event logs
- Atomic model unzip with zip-slip guard

### Changed
- Storage location to Application Support (iOS) / internal files (Android)

### Fixed
- Daily count bucketing by each hit’s UTC date
- readJsonOrEmpty: single read with try-catch fallback
- Snapshot lastAt from flushed hits
- HitLogger rotation without losing trailing writes